### PR TITLE
Fix in stock filter when backorders are enabled

### DIFF
--- a/Plugin/Elasticsuite/InventoryData.php
+++ b/Plugin/Elasticsuite/InventoryData.php
@@ -95,7 +95,7 @@ class InventoryData
 
         $productStatuses = [];
         foreach ($result as $prodId => $indexData) {
-            $isInStock = isset($indexData['stock']) && isset($indexData['stock']['is_in_stock']) && $indexData['stock']['is_in_stock'] ? $inStockValue : $outOfStockValue;
+            $isInStock = (isset($indexData['stock'], $indexData['stock']['qty']) && $indexData['stock']['qty'] > 0) ? $inStockValue : $outOfStockValue;
             $productStatuses[] = [
                 'attribute_id' => $this->attrId,
                 'store_id' => $storeId,


### PR DESCRIPTION
Checks if the quantity is > 0 to determine if a product is out of stock when generating values for the in stock attribute, since `is_in_stock` is true with quantities of less than 0 when backorders are enabled.